### PR TITLE
bugfix: remove space from the oidc request response.

### DIFF
--- a/src/scripts/authenticate_with_oidc.sh
+++ b/src/scripts/authenticate_with_oidc.sh
@@ -23,7 +23,7 @@ RESPONSE=$(curl -X POST -H "Content-Type: application/json" \
             -d "{\"oidc_token\":\"$CIRCLE_OIDC_TOKEN_V2\", \"service_slug\":\"$service_account\"}" \
             --silent --show-error "https://api.cloudsmith.io/openid/$organisation/")
 
-CLOUDSMITH_OIDC_TOKEN=$(echo "$RESPONSE" | grep -o '"token":"[^"]*' | grep -o '[^"]*$')
+CLOUDSMITH_OIDC_TOKEN=$(echo "$RESPONSE" | grep -o '"token"\s*:\s*"[^"]*' | grep -o '[^"]*$')
 
 if [ -z "$CLOUDSMITH_OIDC_TOKEN" ]
 then

--- a/src/scripts/authenticate_with_oidc.sh
+++ b/src/scripts/authenticate_with_oidc.sh
@@ -23,7 +23,7 @@ RESPONSE=$(curl -X POST -H "Content-Type: application/json" \
             -d "{\"oidc_token\":\"$CIRCLE_OIDC_TOKEN_V2\", \"service_slug\":\"$service_account\"}" \
             --silent --show-error "https://api.cloudsmith.io/openid/$organisation/")
 
-CLOUDSMITH_OIDC_TOKEN=$(echo "$RESPONSE" | grep -o '"token": "[^"]*' | grep -o '[^"]*$')
+CLOUDSMITH_OIDC_TOKEN=$(echo "$RESPONSE" | grep -o '"token":"[^"]*' | grep -o '[^"]*$')
 
 if [ -z "$CLOUDSMITH_OIDC_TOKEN" ]
 then


### PR DESCRIPTION
The OIDC token response from the `https://api.cloudsmith.io/openid` has changed and a space has been removed from the response which means the following environment variable is not set correctly.

CLOUDSMITH_OIDC_TOKEN=$(echo "$RESPONSE" | grep -o '"token": "[^"]*' | grep -o '[^"]*$')

This change removes the space after the colon ":" in the grep command.